### PR TITLE
fixed error that was occurring on polygon_to_geohashes(_)

### DIFF
--- a/polyhash.py
+++ b/polyhash.py
@@ -112,8 +112,10 @@ def polygon_to_geohashes(polygon, precision=6, strict=False, compress=False,
 
     if compress and precision > 1:
         minprec = precision - 1
-        inner_geohashes = gcompress(inner_geohashes, minprec, precision)
-        outer_geohashes = gcompress(outer_geohashes, minprec, precision)
+        if len(inner_geohashes) > 0:
+          inner_geohashes = gcompress(inner_geohashes, minprec, precision)
+        if len(outer_geohashes) > 0:
+          outer_geohashes = gcompress(outer_geohashes, minprec, precision)
         if len(border_geohashes) > 0:
             border_geohashes = gcompress(border_geohashes, minprec, precision)
 


### PR DESCRIPTION
This PR should fix an error that was occurring on polygon_to_geohashes(_) when compress=True and the pre-compression values for 'inner' and/or 'outer' were None

I was getting a TypeError with certain inputs when setting `compress=True`. For example, with the following input data:

```
data = {"coordinates": [[[[-176.823926, 0.817036], [-176.768772, 0.663174], [-176.630579, 0.593736], [-176.482493, 0.642735], [-176.411851, 0.78755], [-176.462881, 0.946425], [-176.607757, 1.020922], [-176.758983, 0.966845], [-176.823926, 0.817036]]]], "type": "MultiPolygon"}
```
If I execute:
```
mp = shape(data)
geohashes = polygon_to_geohashes(mp, precision=4, compress=True)
```
I receive the error `TypeError: object of type 'bool' has no len()`.

This PR should fix that issue.